### PR TITLE
Add hold FAB to scroll on top

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -338,6 +338,11 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             updateEditMode(!model.inEditMode)
             if (model.inEditMode) requestFocusForFields(true) else view.hideKeyboard()
         }
+
+        binding.fabChangeMode.setOnLongClickListener {
+            binding.scrollView.smoothScrollTo(0, 0)
+            true
+        }
     }
 
     @Deprecated("Deprecated in Java")

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -339,6 +339,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             if (model.inEditMode) requestFocusForFields(true) else view.hideKeyboard()
         }
 
+        // Hold FAB to sroll on top
         binding.fabChangeMode.setOnLongClickListener {
             binding.scrollView.smoothScrollTo(0, 0)
             true

--- a/app/src/main/java/org/qosp/notes/ui/main/MainFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/main/MainFragment.kt
@@ -207,6 +207,12 @@ open class MainFragment : AbstractNotesFragment(R.layout.fragment_main) {
     private fun setupFab() {
         ViewCompat.setTransitionName(binding.fabCreateNote, "editor_create")
         binding.fabCreateNote.setOnClickListener { goToEditor(sharedElement = binding.fabCreateNote) }
+
+        // Hold FAB to sroll on top
+        binding.fabCreateNote.setOnLongClickListener {
+            recyclerView.smoothScrollToPosition(0)
+            true
+        }
     }
 
     private fun setLayoutChangeActionIcon() {


### PR DESCRIPTION
Added long-press handlers to scroll-to-top on FABs without changing tap behavior

- On the main screen: using `RecyclerView` and `smoothScrollToPosition(0)` (by item index so first)
- In the editor view or edit: using `ScrollView` and `smoothScrollTo(0, 0)` (by pixel coordinates so x,y)