### PR TITLE
Add long-press "more options" to scroll to bottom

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -107,6 +107,10 @@ import org.qosp.notes.ui.utils.shareAttachment
 import org.qosp.notes.ui.utils.shareNote
 import org.qosp.notes.ui.utils.viewBinding
 import org.qosp.notes.ui.utils.views.BottomSheet
+
+import org.qosp.notes.ui.utils.scrollToBottomSmooth
+import org.qosp.notes.ui.utils.setOverflowLongPressAction
+
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -353,6 +357,11 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
 
         lifecycleScope.launch {
             model.data.first().note?.let { setupMenuItems(it, it.reminders.isNotEmpty()) }
+        }
+
+        // Add long-press on overflow (three-dots) to scroll to bottom
+        binding.toolbar.setOverflowLongPressAction {
+            binding.scrollView.scrollToBottomSmooth()
         }
     }
 

--- a/app/src/main/java/org/qosp/notes/ui/main/MainFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/main/MainFragment.kt
@@ -37,6 +37,9 @@ import org.qosp.notes.ui.utils.TakePictureContract
 import org.qosp.notes.ui.utils.navigateSafely
 import org.qosp.notes.ui.utils.viewBinding
 
+import org.qosp.notes.ui.utils.scrollToLastSmooth
+import org.qosp.notes.ui.utils.setOverflowLongPressAction
+
 open class MainFragment : AbstractNotesFragment(R.layout.fragment_main) {
     private val binding by viewBinding(FragmentMainBinding::bind)
 
@@ -114,6 +117,11 @@ open class MainFragment : AbstractNotesFragment(R.layout.fragment_main) {
         setHiddenNotesItemActionText()
         setLayoutChangeActionIcon()
         selectSortMethodItem()
+
+        // Long-press on overflow (three-dots) to scroll to bottom
+        binding.layoutAppBar.toolbar.setOverflowLongPressAction {
+            binding.recyclerMain.scrollToLastSmooth()
+        }
     }
 
     @Deprecated("Deprecated in Java")

--- a/app/src/main/java/org/qosp/notes/ui/utils/ToolbarExtension.kt
+++ b/app/src/main/java/org/qosp/notes/ui/utils/ToolbarExtension.kt
@@ -1,0 +1,48 @@
+package org.qosp.notes.ui.utils
+
+import android.view.View
+import androidx.appcompat.widget.Toolbar
+import androidx.core.view.doOnLayout
+import androidx.recyclerview.widget.RecyclerView
+import android.widget.ScrollView
+import androidx.core.widget.NestedScrollView
+
+fun Toolbar.setOverflowLongPressAction(onLongPress: () -> Unit) {
+    post {
+        val overflowDesc = resources.getString(
+            androidx.appcompat.R.string.abc_action_menu_overflow_description
+        )
+        val overflowButtons = ArrayList<View>()
+        findViewsWithText(
+            overflowButtons,
+            overflowDesc,
+            View.FIND_VIEWS_WITH_CONTENT_DESCRIPTION
+        )
+        overflowButtons.firstOrNull()?.setOnLongClickListener {
+            onLongPress()
+            true
+        }
+    }
+}
+
+// Smoothly scroll a ScrollView to the bottom.
+fun ScrollView.scrollToBottomSmooth() {
+    doOnLayout {
+        smoothScrollTo(0, (getChildAt(0)?.bottom ?: 0) + paddingBottom)
+    }
+}
+
+// Smoothly scroll a NestedScrollView to the bottom.
+fun NestedScrollView.scrollToBottomSmooth() {
+    doOnLayout {
+        smoothScrollTo(0, (getChildAt(0)?.bottom ?: 0) + paddingBottom)
+    }
+}
+
+// Smoothly scroll a RecyclerView to the last item.
+fun RecyclerView.scrollToLastSmooth() {
+    post {
+        val last = adapter?.itemCount?.minus(1) ?: -1
+        if (last >= 0) smoothScrollToPosition(last)
+    }
+}


### PR DESCRIPTION
Smooth scroll to bottom for: Main notes screen, and Editor screen in both view and edit modes

- The extensions in `ToolbarExtensions.kt` handle the "find the overflow button and attach long-press" logic.
- Each fragment just tells it what to do on long-press.

| Fragment       | Toolbar overflow long-press  | Scroll action                       |
| -------------- | ---------------------------- | ----------------------------------- |
| EditorFragment | binding.toolbar              | scrollView → scrollToBottomSmooth() |
| MainFragment   | binding.layoutAppBar.toolbar | recyclerView → scrollToLastSmooth() |