### PR TITLE
Fix layout mode bug: preserve `previousLayoutMode` before updating `data`

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/common/AbstractNotesFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/common/AbstractNotesFragment.kt
@@ -273,8 +273,8 @@ abstract class AbstractNotesFragment(@LayoutRes resId: Int) : BaseFragment(resId
 
     @CallSuper
     open fun onDataChanged(data: Data) {
-        this.data = data
         val previousLayoutMode = this.data.layoutMode
+        this.data = data
 
         // Submit the list to the adapter
         onNotesChanged(data.notes)


### PR DESCRIPTION
- Moved `val previousLayoutMode = this.data.layoutMode` **above** `this.data = data` in `onDataChanged()`
- Ensures that `previousLayoutMode` correctly reflects the old state before the data update

Without this, layout mode handling breaks (e.g. when trying to change the `Layout mode`) and `RecyclerView` may not update properly.

This fixes the issue introduced in the merged branch `fix/scroll-jump-on-top`