### PR TITLE
Add note count to toolbar titles

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/archive/ArchiveFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/archive/ArchiveFragment.kt
@@ -37,7 +37,7 @@ class ArchiveFragment : AbstractNotesFragment(R.layout.fragment_archive) {
     override val toolbar: Toolbar
         get() = binding.layoutAppBar.toolbar
     override val toolbarTitle: String
-        get() = getString(R.string.nav_archive)
+        get() = "${data.notes.size} ${getString(R.string.nav_archive)}"
     override val secondaryToolbar: Toolbar
         get() = binding.layoutAppBar.toolbarSelection
     override val secondaryToolbarMenuRes: Int = R.menu.archive_selected_notes

--- a/app/src/main/java/org/qosp/notes/ui/common/AbstractNotesFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/common/AbstractNotesFragment.kt
@@ -294,6 +294,9 @@ abstract class AbstractNotesFragment(@LayoutRes resId: Int) : BaseFragment(resId
 
         onLayoutModeChanged()
         onSortMethodChanged()
+
+        // Update toolbar title to reflect current note count
+        updateToolbarTitle()
     }
 
     open fun onNotesChanged(notes: List<Note>) {

--- a/app/src/main/java/org/qosp/notes/ui/common/BaseFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/common/BaseFragment.kt
@@ -58,4 +58,8 @@ open class BaseFragment(@LayoutRes resId: Int) : Fragment(resId) {
     protected fun sendMessage(message: String) {
         setFragmentResult(FRAGMENT_MESSAGE, bundleOf(FRAGMENT_MESSAGE to message))
     }
+
+    protected fun updateToolbarTitle() {
+        (activity as? MainActivity)?.supportActionBar?.title = toolbarTitle
+    }
 }

--- a/app/src/main/java/org/qosp/notes/ui/deleted/DeletedFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/deleted/DeletedFragment.kt
@@ -39,7 +39,7 @@ class DeletedFragment : AbstractNotesFragment(R.layout.fragment_deleted) {
     override val toolbar: Toolbar
         get() = binding.layoutAppBar.toolbar
     override val toolbarTitle: String
-        get() = getString(R.string.nav_deleted)
+        get() = "${data.notes.size} ${getString(R.string.nav_deleted)}"
     override val secondaryToolbar: Toolbar
         get() = binding.layoutAppBar.toolbarSelection
     override val secondaryToolbarMenuRes = R.menu.deleted_selected_notes

--- a/app/src/main/java/org/qosp/notes/ui/main/MainFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/main/MainFragment.kt
@@ -89,7 +89,7 @@ open class MainFragment : AbstractNotesFragment(R.layout.fragment_main) {
     override val toolbar: Toolbar
         get() = binding.layoutAppBar.toolbar
     override val toolbarTitle: String
-        get() = getString(R.string.nav_notes)
+        get() = "${data.notes.size} ${getString(R.string.nav_notes)}"
     override val secondaryToolbar: Toolbar
         get() = binding.layoutAppBar.toolbarSelection
     override val secondaryToolbarMenuRes: Int = R.menu.main_selected_notes


### PR DESCRIPTION
Provides immediate visual feedback on note collection size without needing to scroll or count manually.

- [x] add note count to main screen toolbar titles
- [x] add note count to deleted and archived fragments toolbar titles

---

### Main screen
- Display current note count before `Notes` text in main screen toolbar
- Title format: `{count} Notes` (e.g., "5 Notes", "12 Notes", "0 Notes")
- Automatically updates when notes are added, deleted, restored, or modified
- Works across all supported languages using existing `nav_notes` string resource
- Adds `updateToolbarTitle()` method to `BaseFragment` for dynamic title updates
- Calls `updateToolbarTitle()` in `onDataChanged()` to keep count current

### Archived and Deleted screens
- Extend note count display to deleted notes (bin) and archived notes fragments
- Deleted fragment now shows `{count} Deleted` (e.g., "3 Deleted")
- Archive fragment now shows `{count} Archive` (e.g., "2 Archive")
- Maintains consistency with main notes fragment which shows `{count} Notes`
- All counts update automatically when notes are moved between states
- Leverages existing `updateToolbarTitle()` infrastructure from `AbstractNotesFragment`