### PR TITLE
Resolve random color bug from colored notes + AMOLED note & light theme tweaks

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/common/recycler/NoteViewHolder.kt
+++ b/app/src/main/java/org/qosp/notes/ui/common/recycler/NoteViewHolder.kt
@@ -57,7 +57,7 @@ class NoteViewHolder(
     }
 
     private fun updateBackgroundColor(color: NoteColor) {
-        color.resId(context, true)?.let { resId ->
+        color.resId(context)?.let { resId ->
             binding.root.setCardBackgroundColor(resId)
             binding.linearLayout.setBackgroundColor(resId)
         }

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -890,7 +890,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             notebookView.text = data.notebook?.name ?: getString(R.string.notebooks_unassigned)
 
             // Update fragment background colour
-            data.note.color.resId(requireContext(), false)?.let { resId ->
+            data.note.color.resId(requireContext())?.let { resId ->
                 backgroundColor = resId
                 root.setBackgroundColor(resId)
                 containerBottomToolbar.setBackgroundColor(resId)

--- a/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/editor/EditorFragment.kt
@@ -102,6 +102,7 @@ import org.qosp.notes.ui.utils.liftAppBarOnScroll
 import org.qosp.notes.ui.utils.navigateSafely
 import org.qosp.notes.ui.utils.requestFocusAndKeyboard
 import org.qosp.notes.ui.utils.resId
+import org.qosp.notes.ui.utils.resIdForEditor
 import org.qosp.notes.ui.utils.resolveAttribute
 import org.qosp.notes.ui.utils.shareAttachment
 import org.qosp.notes.ui.utils.shareNote
@@ -890,7 +891,7 @@ class EditorFragment : BaseFragment(R.layout.fragment_editor) {
             notebookView.text = data.notebook?.name ?: getString(R.string.notebooks_unassigned)
 
             // Update fragment background colour
-            data.note.color.resId(requireContext())?.let { resId ->
+            data.note.color.resIdForEditor(requireContext())?.let { resId ->
                 backgroundColor = resId
                 root.setBackgroundColor(resId)
                 containerBottomToolbar.setBackgroundColor(resId)

--- a/app/src/main/java/org/qosp/notes/ui/utils/ContextUtils.kt
+++ b/app/src/main/java/org/qosp/notes/ui/utils/ContextUtils.kt
@@ -18,7 +18,7 @@ fun Context.getDimensionAttribute(attr: Int): Int? {
     return resolveAttribute(attr)?.let { TypedValue.complexToDimensionPixelSize(it, resources.displayMetrics) }
 }
 
-fun NoteColor.resId(context: Context, isInListView: Boolean = false): Int? {
+fun NoteColor.resId(context: Context): Int? {
     val resId = when (this) {
         NoteColor.Green -> R.attr.colorNoteGreen
         NoteColor.Pink -> R.attr.colorNotePink
@@ -26,7 +26,7 @@ fun NoteColor.resId(context: Context, isInListView: Boolean = false): Int? {
         NoteColor.Red -> R.attr.colorNoteRed
         NoteColor.Orange -> R.attr.colorNoteOrange
         NoteColor.Yellow -> R.attr.colorNoteYellow
-        else -> if (isInListView) R.attr.colorNoteListDefault else R.attr.colorNoteDefault
+        else -> R.attr.colorNoteDefault
     }
 
     return context.resolveAttribute(resId)

--- a/app/src/main/java/org/qosp/notes/ui/utils/ContextUtils.kt
+++ b/app/src/main/java/org/qosp/notes/ui/utils/ContextUtils.kt
@@ -31,3 +31,16 @@ fun NoteColor.resId(context: Context): Int? {
 
     return context.resolveAttribute(resId)
 }
+
+fun NoteColor.resIdForEditor(context: Context): Int? {
+    // For AMOLED theme in editor mode, use black for default color
+    if (this == NoteColor.Default) {
+        // Check if AMOLED theme in one call instead of separate function
+        val backgroundColor = context.resolveAttribute(R.attr.colorBackground)
+        if (backgroundColor == android.graphics.Color.BLACK) {
+            return android.graphics.Color.BLACK
+        }
+    }
+
+    return resId(context)
+}

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -40,7 +40,6 @@
         <item name="colorHighlightMask">#1FFFFFFF</item>
 
         <item name="colorNoteDefault">?attr/colorSurface</item>
-<!--        <item name="colorNoteListDefault">#242127</item>-->
         <item name="colorNoteGreen">#38573A</item>
         <item name="colorNotePink">#5C2940</item>
         <item name="colorNoteBlue">#273749</item>
@@ -48,7 +47,7 @@
         <item name="colorNoteOrange">#65452A</item>
         <item name="colorNoteYellow">#68643A</item>
 
-        <item name="colorNoteTextHighlight">#96FFFF00</item>
+        <item name="colorNoteTextHighlight">#D7C374</item>
 
         <item name="popupTheme">@style/Widget.Custom.PopupMenu</item>
         <item name="materialAlertDialogTheme">@style/DialogTheme</item>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -67,7 +67,7 @@
         <item name="colorOnSecondaryContainer">#D8EDFF</item>
         <item name="colorSurfaceContainerLow">#1E2734</item>
         <item name="colorSurfaceDim">#162030</item>
-        <item name="colorNoteListDefault">#1E2734</item>
+        <item name="colorNoteDefault">#1E2734</item>
 
         <item name="colorDrawerHeaderBackground">#3390CAF9</item>
         <item name="colorPrimaryTranscluent">#2690CAF9</item>
@@ -83,7 +83,7 @@
         <item name="colorOnSecondaryContainer">#E4F5D3</item>
         <item name="colorSurfaceContainerLow">#202A18</item>
         <item name="colorSurfaceDim">#182214</item>
-        <item name="colorNoteListDefault">#202A18</item>
+        <item name="colorNoteDefault">#202A18</item>
 
         <item name="colorDrawerHeaderBackground">#33C5E1A5</item>
         <item name="colorPrimaryTranscluent">#26C5E1A5</item>
@@ -99,7 +99,7 @@
         <item name="colorOnSecondaryContainer">#FFD9E2</item>
         <item name="colorSurfaceContainerLow">#321B25</item>
         <item name="colorSurfaceDim">#28141E</item>
-        <item name="colorNoteListDefault">#321B25</item>
+        <item name="colorNoteDefault">#321B25</item>
 
         <item name="colorDrawerHeaderBackground">#33F48FB1</item>
         <item name="colorPrimaryTranscluent">#26F48FB1</item>
@@ -115,7 +115,7 @@
         <item name="colorOnSecondaryContainer">#FFECD2</item>
         <item name="colorSurfaceContainerLow">#2D2318</item>
         <item name="colorSurfaceDim">#251C12</item>
-        <item name="colorNoteListDefault">#2D2318</item>
+        <item name="colorNoteDefault">#2D2318</item>
 
         <item name="colorDrawerHeaderBackground">#33FFCC80</item>
         <item name="colorPrimaryTranscluent">#26FFCC80</item>
@@ -131,7 +131,7 @@
         <item name="colorOnSecondaryContainer">#E9DDFF</item>
         <item name="colorSurfaceContainerLow">#26203A</item>
         <item name="colorSurfaceDim">#1E1A30</item>
-        <item name="colorNoteListDefault">#26203A</item>
+        <item name="colorNoteDefault">#26203A</item>
 
         <item name="colorDrawerHeaderBackground">#33B39DDB</item>
         <item name="colorPrimaryTranscluent">#26B39DDB</item>

--- a/app/src/main/res/values/attr.xml
+++ b/app/src/main/res/values/attr.xml
@@ -30,7 +30,6 @@
     <attr name="colorAttachmentIndicator" format="color"/>
 
     <attr name="colorNoteDefault" format="color"/>
-    <attr name="colorNoteListDefault" format="color"/>
     <attr name="colorNoteGreen" format="color"/>
     <attr name="colorNotePink" format="color"/>
     <attr name="colorNoteBlue" format="color"/>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -59,8 +59,9 @@
         <item name="colorBackground">#000000</item>
         <item name="colorSurface">?attr/colorSurfaceDim</item>
         <item name="elevationOverlayEnabled">false</item>
-        <item name="colorNoteDefault">#000000</item>
-        <item name="colorNoteListDefault">?attr/colorSurfaceDim</item>
+        <!--<item name="colorNoteDefault">#000000</item>-->
+        <item name="colorNoteDefault">?attr/colorSurfaceDim</item>
+        <!--<item name="colorNoteListDefault">?attr/colorSurfaceDim</item>-->
         <item name="colorDrawerBackground">?attr/colorSurfaceDim</item>
         <item name="colorBottomAppBarBackground">#000000</item>
 <!--        <item name="android:navigationBarColor">#090909</item>-->
@@ -77,7 +78,7 @@
         <item name="colorSecondaryContainer">#B5E2F8</item>
         <item name="colorOnSecondaryContainer">#001E30</item>
         <item name="colorSurfaceContainerLow">#EEF8FF</item>
-        <item name="colorNoteListDefault">#EEF8FF</item>
+        <item name="colorNoteDefault">#EEF8FF</item>
 
         <item name="colorDrawerHeaderBackground">#992196F3</item>
         <item name="colorPrimaryTranscluent">#332196F3</item>
@@ -92,7 +93,7 @@
         <item name="colorSecondaryContainer">#D7F9AA</item>
         <item name="colorOnSecondaryContainer">#122007</item>
         <item name="colorSurfaceContainerLow">#F1F8EB</item>
-        <item name="colorNoteListDefault">#F1F8EB</item>
+        <item name="colorNoteDefault">#F1F8EB</item>
 
         <item name="colorDrawerHeaderBackground">#997CB342</item>
         <item name="colorPrimaryTranscluent">#337CB342</item>
@@ -106,7 +107,7 @@
         <item name="colorSecondaryContainer">#FBC7D3</item>
         <item name="colorOnSecondaryContainer">#3E001D</item>
         <item name="colorSurfaceContainerLow">#FFF1F5</item>
-        <item name="colorNoteListDefault">#FFF1F5</item>
+        <item name="colorNoteDefault">#FFF1F5</item>
 
         <item name="colorDrawerHeaderBackground">#80C2185B</item>
         <item name="colorPrimaryTranscluent">#29C2185B</item>
@@ -121,7 +122,7 @@
         <item name="colorSecondaryContainer">#FCE392</item>
         <item name="colorOnSecondaryContainer">#261900</item>
         <item name="colorSurfaceContainerLow">#FFF7EA</item>
-        <item name="colorNoteListDefault">#FFF7EA</item>
+        <item name="colorNoteDefault">#FFF7EA</item>
 
         <item name="colorDrawerHeaderBackground">#99FFB300</item>
         <item name="colorPrimaryTranscluent">#29E39F00</item>
@@ -136,7 +137,7 @@
         <item name="colorSecondaryContainer">#DDCBF8</item>
         <item name="colorOnSecondaryContainer">#1A0046</item>
         <item name="colorSurfaceContainerLow">#F3EEFA</item>
-        <item name="colorNoteListDefault">#F3EEFA</item>
+        <item name="colorNoteDefault">#F3EEFA</item>
 
         <item name="colorDrawerHeaderBackground">#99673AB7</item>
         <item name="colorPrimaryTranscluent">#29673AB7</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -38,12 +38,12 @@
         <item name="colorHighlightMask">#1F000000</item>
 
         <item name="colorNoteDefault">#FFFFFF</item>
-        <item name="colorNoteGreen">#C5E1A5</item>
-        <item name="colorNotePink">#F48FB1</item>
-        <item name="colorNoteBlue">#81D4FA</item>
-        <item name="colorNoteRed">#EF9A9A</item>
-        <item name="colorNoteOrange">#FFAB91</item>
-        <item name="colorNoteYellow">#FFF59D</item>
+        <item name="colorNoteGreen">#E0F2E0</item>
+        <item name="colorNotePink">#FAE8FF</item>
+        <item name="colorNoteBlue">#E6F3FF</item>
+        <item name="colorNoteRed">#FFDFDF</item>
+        <item name="colorNoteOrange">#FFEBCC</item>
+        <item name="colorNoteYellow">#FFF7D6</item>
 
         <item name="colorNoteTextHighlight">#96FFFF00</item>
 
@@ -59,26 +59,23 @@
         <item name="colorBackground">#000000</item>
         <item name="colorSurface">?attr/colorSurfaceDim</item>
         <item name="elevationOverlayEnabled">false</item>
-        <!--<item name="colorNoteDefault">#000000</item>-->
         <item name="colorNoteDefault">?attr/colorSurfaceDim</item>
-        <!--<item name="colorNoteListDefault">?attr/colorSurfaceDim</item>-->
         <item name="colorDrawerBackground">?attr/colorSurfaceDim</item>
         <item name="colorBottomAppBarBackground">#000000</item>
-<!--        <item name="android:navigationBarColor">#090909</item>-->
         <item name="android:navigationBarColor">
             @android:color/transparent
         </item>
     </style>
 
     <style name="Blue">
-        <item name="colorPrimary">#087DC6</item>
+        <item name="colorPrimary">#3B7EAD</item>
         <item name="colorPrimaryDark">@android:color/transparent</item>
-        <item name="colorSecondary">#2196f3</item>
+        <item name="colorSecondary">#56B5F6</item>
 
-        <item name="colorSecondaryContainer">#B5E2F8</item>
+        <item name="colorSecondaryContainer">#C0DDEB</item>
         <item name="colorOnSecondaryContainer">#001E30</item>
         <item name="colorSurfaceContainerLow">#EEF8FF</item>
-        <item name="colorNoteDefault">#EEF8FF</item>
+        <item name="colorNoteDefault">#E6EEF4</item>
 
         <item name="colorDrawerHeaderBackground">#992196F3</item>
         <item name="colorPrimaryTranscluent">#332196F3</item>
@@ -86,28 +83,28 @@
     </style>
 
     <style name="Green">
-        <item name="colorPrimary">#7CB342</item>
+        <item name="colorPrimary">#608A34</item>
         <item name="colorPrimaryDark">@android:color/transparent</item>
         <item name="colorSecondary">#7CB342</item>
 
-        <item name="colorSecondaryContainer">#D7F9AA</item>
+        <item name="colorSecondaryContainer">#BFD0B1</item>
         <item name="colorOnSecondaryContainer">#122007</item>
         <item name="colorSurfaceContainerLow">#F1F8EB</item>
-        <item name="colorNoteDefault">#F1F8EB</item>
+        <item name="colorNoteDefault">#E7EFE2</item>
 
         <item name="colorDrawerHeaderBackground">#997CB342</item>
         <item name="colorPrimaryTranscluent">#337CB342</item>
     </style>
 
     <style name="Pink">
-        <item name="colorPrimary">#C2185B</item>
+        <item name="colorPrimary">#AB3A87</item>
         <item name="colorPrimaryDark">@android:color/transparent</item>
         <item name="colorSecondary">#C2185B</item>
 
-        <item name="colorSecondaryContainer">#FBC7D3</item>
+        <item name="colorSecondaryContainer">#E7CED3</item>
         <item name="colorOnSecondaryContainer">#3E001D</item>
         <item name="colorSurfaceContainerLow">#FFF1F5</item>
-        <item name="colorNoteDefault">#FFF1F5</item>
+        <item name="colorNoteDefault">#FAEDF2</item>
 
         <item name="colorDrawerHeaderBackground">#80C2185B</item>
         <item name="colorPrimaryTranscluent">#29C2185B</item>
@@ -115,14 +112,14 @@
     </style>
 
     <style name="Orange">
-        <item name="colorPrimary">#E47400</item>
+        <item name="colorPrimary">#C16C15</item>
         <item name="colorPrimaryDark">@android:color/transparent</item>
-        <item name="colorSecondary">#FFB300</item>
+        <item name="colorSecondary">#F2922E</item>
 
-        <item name="colorSecondaryContainer">#FCE392</item>
+        <item name="colorSecondaryContainer">#E2C7AB</item>
         <item name="colorOnSecondaryContainer">#261900</item>
         <item name="colorSurfaceContainerLow">#FFF7EA</item>
-        <item name="colorNoteDefault">#FFF7EA</item>
+        <item name="colorNoteDefault">#F6EEE1</item>
 
         <item name="colorDrawerHeaderBackground">#99FFB300</item>
         <item name="colorPrimaryTranscluent">#29E39F00</item>
@@ -137,7 +134,7 @@
         <item name="colorSecondaryContainer">#DDCBF8</item>
         <item name="colorOnSecondaryContainer">#1A0046</item>
         <item name="colorSurfaceContainerLow">#F3EEFA</item>
-        <item name="colorNoteDefault">#F3EEFA</item>
+        <item name="colorNoteDefault">#EDE9F4</item>
 
         <item name="colorDrawerHeaderBackground">#99673AB7</item>
         <item name="colorPrimaryTranscluent">#29673AB7</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 activityCompose = "1.10.1"
 activityKtx = "1.10.1"
-androidGradlePlugin = "8.11.0"
+androidGradlePlugin = "8.12.2"
 androidxComposeBom = "2025.07.00"
 androidxTest = "1.7.0"
 appcompat = "1.7.1"


### PR DESCRIPTION
### BUG FIX: Random color issue with custom notes

* Previously, enabling **custom-colored notes** caused **non-colored notes** to randomly change their colors while scrolling, across **all theme modes**.
* The bug originated from my old background resolution (using `isListNoteView` and `colorNoteListDefault`) logic, which incorrectly handled default vs. custom note colors.
* This PR **rewrites the background resolution logic** to be simpler, correct, and predictable:

  * Introduces `NoteColor.resIdForEditor()` extension to determine proper bg color.
  * Removes redundant variables (kt - `isListNoteView`, xml - `colorNoteListDefault`).
  * Ensures custom-colored notes now maintain their assigned color consistently.
  * Default notes no longer adopt random colors during scrolling.

---

### FEATURE: AMOLED note editor mode fix

* When **AMOLED theme** is active:

  * **List view:** default notes use `colorSurfaceDim` (material-colored, not black).
  * **Editor view:** default notes switch to **pure black** for better contrast and readability.
* Custom-colored notes are unaffected.
* This resolves the earlier behavior where default notes incorrectly inherited colors in AMOLED editor mode.

---

### REFACTOR: Light static theme tweaks

* Adjusts color palette for **light static themes** to improve visual harmony and contrast:

  * Tweaked **colored note backgrounds** for readability.
  * Updated **tag backgrounds** (`colorSecondaryContainer`) for better visibility.
  * Adjusted **icon colors** (`colorSecondary`) for clarity.
* These tweaks **only affect light themes** and do not interfere with dark or AMOLED modes.
