### PR TITLE
Make tag name sorting case-insensitive

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/tags/TagsFragment.kt
+++ b/app/src/main/java/org/qosp/notes/ui/tags/TagsFragment.kt
@@ -115,9 +115,9 @@ class TagsFragment : BaseFragment(R.layout.fragment_tags) {
                 when (sort) {
                     SortTagsMethod.CREATION_ASC.name -> it.sortedBy { it.tag.id }
                     SortTagsMethod.CREATION_DESC.name -> it.sortedByDescending { it.tag.id }
-                    SortTagsMethod.TITLE_ASC.name -> it.sortedBy { it.tag.name }
-                    SortTagsMethod.TITLE_DESC.name -> it.sortedByDescending { it.tag.name }
-                    else -> it.sortedBy { it.tag.name }
+                    SortTagsMethod.TITLE_ASC.name -> it.sortedBy { it.tag.name.lowercase() }
+                    SortTagsMethod.TITLE_DESC.name -> it.sortedByDescending { it.tag.name.lowercase() }
+                    else -> it.sortedBy { it.tag.name.lowercase() }
                 }
             }
 


### PR DESCRIPTION
Resolving issue when sorting tags by name, uppercase and lowercase characters were treated differently.

- Achieved by normalizing strings before comparison with `tolowercase()`
- `Apple` and `apple` now sort together as expected.