### PR TITLE
Show `Untitled` indicator for empty titles in compact view and add opacity to it

### DIFF
--- a/app/src/main/java/org/qosp/notes/ui/common/recycler/NoteViewHolder.kt
+++ b/app/src/main/java/org/qosp/notes/ui/common/recycler/NoteViewHolder.kt
@@ -113,11 +113,21 @@ class NoteViewHolder(
     }
 
     private fun setTitle(note: Note) {
-        if (note.title.isEmpty()) {
-            binding.textViewTitle.isVisible = false
-        } else {
-            binding.textViewTitle.isVisible = true
-            binding.textViewTitle.text = note.title
+        when {
+            note.title.isNotEmpty() -> {
+                binding.textViewTitle.isVisible = true
+                binding.textViewTitle.text = note.title
+                binding.textViewTitle.alpha = 1f
+            }
+            note.isCompactPreview -> {
+                binding.textViewTitle.isVisible = true
+                binding.textViewTitle.setText(R.string.indicator_untitled)
+                binding.textViewTitle.alpha = 0.4f
+            }
+            else -> {
+                binding.textViewTitle.isVisible = false
+                binding.textViewTitle.alpha = 1f
+            }
         }
     }
 


### PR DESCRIPTION
Closes #11 

FIX QUILLPAD ISSUE #601: Compact preview is empty

- Display a dimmed "Untitled" placeholdr when a note has no title and is in compact preview mode
- Use 0.4 alpha to visually distimguish the sys placeholder from user-entered titles
- Ensure title alpha and visibility are reset during view recycling to prevent UI glitches
- Refactor "setTitle" to use a more readable "when" block
