### PR TITLE
Remove my old bold `textStyle` and `fontFamily` from `NoteBody`

### DIFF
--- a/app/src/main/res/font/inter_font_family.xml
+++ b/app/src/main/res/font/inter_font_family.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<font-family
-        xmlns:app="http://schemas.android.com/apk/res-auto">
+<font-family xmlns:app="http://schemas.android.com/apk/res-auto">
     <font
-            app:fontStyle="normal"
-            app:fontWeight="400"
-            app:font="@font/inter_regular"/>
-
-<!--    <font-->
-<!--        app:fontStyle="normal"-->
-<!--        app:fontWeight="500"-->
-<!--        app:font="@font/inter_medium"/>-->
+        app:fontStyle="normal"
+        app:fontWeight="400"
+        app:font="@font/inter_regular"/>
 
     <font
-            app:fontStyle="normal"
-            app:fontWeight="700"
-            app:font="@font/inter_semibold"/>
+        app:fontStyle="normal"
+        app:fontWeight="500"
+        app:font="@font/inter_medium"/>
+
+    <font
+        app:fontStyle="normal"
+        app:fontWeight="600"
+        app:font="@font/inter_semibold"/>
+
+    <font
+        app:fontStyle="normal"
+        app:fontWeight="700"
+        app:font="@font/inter_bold"/>
 </font-family>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -59,7 +59,8 @@
     <style name="TextAppearance.Custom.NoteBody" parent="TextAppearance.MaterialComponents.Body1">
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">?attr/colorNoteText</item>
-        <item name="android:textStyle">bold</item>
+<!--        <item name="android:fontFamily">@font/inter_font_family</item>-->
+<!--        <item name="android:textStyle">bold</item>-->
     </style>
 
 <!--    <style name="NoteIcon">-->


### PR DESCRIPTION
Also ensured that "inter_font_family.xml" correctly maps font weights (400-700) so that`android:textStyle="bold"` correctly loads the bold font file
